### PR TITLE
Add state change logging

### DIFF
--- a/examples/log.py
+++ b/examples/log.py
@@ -1,0 +1,11 @@
+from .turnstile import Turnstile
+
+
+class TurnstileWithLog(Turnstile):
+    def __init__(self):
+        super().__init__()
+        self.history = [self.state]
+
+    def on_state_change(self, source, target):
+        if source != target:
+            self.history.append(target)

--- a/finite_state_machine/state_machine.py
+++ b/finite_state_machine/state_machine.py
@@ -14,6 +14,13 @@ class StateMachine:
         except AttributeError:
             raise ValueError("Need to set a state instance variable")
 
+    def _update_state(self, state):
+        self.on_state_change(self.state, state)
+        self.state = state
+
+    def on_state_change(self, source, target):
+        pass
+
 
 class TransitionDetails(NamedTuple):
     name: str
@@ -86,18 +93,18 @@ class transition:
 
             if not self.on_error:
                 result = func(*args, **kwargs)
-                state_machine.state = self.target
+                state_machine._update_state(self.target)
                 return result
 
             try:
                 result = func(*args, **kwargs)
-                state_machine.state = self.target
+                state_machine._update_state(self.target)
                 return result
             except Exception:
                 # TODO should we log this somewhere?
                 # logger.error? maybe have an optional parameter to set this up
                 # how to libraries log?
-                state_machine.state = self.on_error
+                state_machine._update_state(self.on_error)
                 return
 
         @functools.wraps(func)
@@ -127,18 +134,18 @@ class transition:
 
             if not self.on_error:
                 result = await func(*args, **kwargs)
-                state_machine.state = self.target
+                state_machine._update_state(self.target)
                 return result
 
             try:
                 result = await func(*args, **kwargs)
-                state_machine.state = self.target
+                state_machine._update_state(self.target)
                 return result
             except Exception:
                 # TODO should we log this somewhere?
                 # logger.error? maybe have an optional parameter to set this up
                 # how to libraries log?
-                state_machine.state = self.on_error
+                state_machine._update_state(self.on_error)
                 return
 
         if asyncio.iscoroutinefunction(func):

--- a/tests/examples/test_log.py
+++ b/tests/examples/test_log.py
@@ -1,0 +1,30 @@
+import pytest
+
+from finite_state_machine.exceptions import InvalidStartState
+from examples.log import TurnstileWithLog
+
+
+def test_turnstile():
+    t = TurnstileWithLog()
+    assert t.state == "close"
+    assert t.history == ["close"]
+
+    t.insert_coin()
+    assert t.state == "open"
+    assert t.history == ["close", "open"]
+
+    t.insert_coin()
+    assert t.state == "open"
+    assert t.history == ["close", "open"]
+
+    t.pass_thru()
+    assert t.state == "close"
+    assert t.history == ["close", "open", "close"]
+
+
+def test_turnstile__cannot_pass_thru_closed_turnstile():
+    t = TurnstileWithLog()
+    assert t.state == "close"
+
+    with pytest.raises(InvalidStartState, match="Current state is close"):
+        t.pass_thru()


### PR DESCRIPTION
`StateMachine` may implement a state change logger (`on_state_change` method) as shown in the log example

```py
class TurnstileWithLog(Turnstile):
    def __init__(self):
        super().__init__()
        self.history = [self.state]

    def on_state_change(self, source, target):
        if source != target:
            self.history.append(target)
```

that keeps an history of the distinct state changes.

I will had some documentation if the feature is accepted.